### PR TITLE
Investigate and resolve 5glabx user access issues

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,10 +5,17 @@ export async function middleware(req: NextRequest) {
   // For static export, we'll handle authentication client-side
   // This middleware just provides basic routing logic without server-side auth
   
+  // Allow embedding our own pages and especially `/5glabx/*` in iframes
+  const { pathname } = new URL(req.url);
+  if (pathname.startsWith('/5glabx/')) {
+    return NextResponse.next();
+  }
+
   const response = NextResponse.next();
   
   // Add security headers
-  response.headers.set('X-Frame-Options', 'DENY');
+  // Use SAMEORIGIN so the dashboard can embed same-origin iframes
+  response.headers.set('X-Frame-Options', 'SAMEORIGIN');
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('X-XSS-Protection', '1; mode=block');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
@@ -25,6 +32,6 @@ export const config = {
      * - favicon.ico (favicon file)
      * - public folder
      */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|5glabx/.*|.*\\.(?:svg|png|jpg|jpeg|gif|webp|html|js|css)$).*)',
   ],
 };


### PR DESCRIPTION
Allow user dashboard to embed 5GLabX platform by adjusting `X-Frame-Options` and middleware path exclusions.

Users were unable to access the 5GLabX platform from the user dashboard because the application's security headers (`X-Frame-Options: DENY`) prevented the embedding of the 5GLabX UI via an iframe. This change updates the header to `SAMEORIGIN` and excludes 5GLabX paths from general middleware processing to resolve the blocking.

---
<a href="https://cursor.com/background-agent?bcId=bc-36feeae7-1a7a-4a6a-b9fd-a564cadae5b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36feeae7-1a7a-4a6a-b9fd-a564cadae5b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

