### PR TITLE
Deep codebase and sql check for tests

### DIFF
--- a/supabase/migrations/010_test_configuration_tables.sql
+++ b/supabase/migrations/010_test_configuration_tables.sql
@@ -202,6 +202,37 @@ ALTER TABLE public.test_configuration_sharing ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.test_configuration_versions ENABLE ROW LEVEL SECURITY;
 
 -- Test configurations RLS policies
+-- Ensure idempotent policy creation by dropping existing policies if present
+DROP POLICY IF EXISTS "Users can view their own configurations" ON public.test_configurations;
+DROP POLICY IF EXISTS "Users can view public configurations" ON public.test_configurations;
+DROP POLICY IF EXISTS "Users can view shared configurations" ON public.test_configurations;
+DROP POLICY IF EXISTS "Users can create their own configurations" ON public.test_configurations;
+DROP POLICY IF EXISTS "Users can update their own configurations" ON public.test_configurations;
+DROP POLICY IF EXISTS "Users can delete their own configurations" ON public.test_configurations;
+DROP POLICY IF EXISTS "Admins can manage all configurations" ON public.test_configurations;
+
+DROP POLICY IF EXISTS "Users can view public templates" ON public.test_configuration_templates;
+DROP POLICY IF EXISTS "Users can view their own templates" ON public.test_configuration_templates;
+DROP POLICY IF EXISTS "Users can create templates" ON public.test_configuration_templates;
+DROP POLICY IF EXISTS "Users can update their own templates" ON public.test_configuration_templates;
+DROP POLICY IF EXISTS "Users can delete their own templates" ON public.test_configuration_templates;
+DROP POLICY IF EXISTS "Admins can manage all templates" ON public.test_configuration_templates;
+
+DROP POLICY IF EXISTS "Users can view their own usage" ON public.test_configuration_usage;
+DROP POLICY IF EXISTS "Users can create usage records" ON public.test_configuration_usage;
+DROP POLICY IF EXISTS "Admins can view all usage" ON public.test_configuration_usage;
+
+DROP POLICY IF EXISTS "Users can view sharing of their configurations" ON public.test_configuration_sharing;
+DROP POLICY IF EXISTS "Users can view sharing with them" ON public.test_configuration_sharing;
+DROP POLICY IF EXISTS "Users can create sharing for their configurations" ON public.test_configuration_sharing;
+DROP POLICY IF EXISTS "Users can update sharing of their configurations" ON public.test_configuration_sharing;
+DROP POLICY IF EXISTS "Users can delete sharing of their configurations" ON public.test_configuration_sharing;
+DROP POLICY IF EXISTS "Admins can manage all sharing" ON public.test_configuration_sharing;
+
+DROP POLICY IF EXISTS "Users can view versions of their configurations" ON public.test_configuration_versions;
+DROP POLICY IF EXISTS "Users can create versions for their configurations" ON public.test_configuration_versions;
+DROP POLICY IF EXISTS "Admins can manage all versions" ON public.test_configuration_versions;
+
 CREATE POLICY "Users can view their own configurations" ON public.test_configurations
     FOR SELECT USING (user_id = auth.uid());
 


### PR DESCRIPTION
Add idempotency guards to SQL migration files to ensure conflict-free and re-runnable execution in Supabase.

The previous migration order and content had potential conflicts with RLS policy re-creation, trigger re-creation, and conditional index creation due to varying column names (e.g., `user_id` vs `created_by` for `alert_rules`, `event_type` vs `type` for `security_events`). These changes ensure that the migrations can be run multiple times without errors and adapt to slight schema variations.

---
<a href="https://cursor.com/background-agent?bcId=bc-189270d4-0164-4957-90d2-b32f6e183651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-189270d4-0164-4957-90d2-b32f6e183651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

