### PR TITLE
Insert e2e test cases handling duplicates

### DIFF
--- a/database/insert_e2e_test_cases.sql
+++ b/database/insert_e2e_test_cases.sql
@@ -8,7 +8,7 @@ INSERT INTO test_cases (
     estimated_duration_minutes, automation_level, review_status, layer,
     standard_reference, is_active, is_premium, is_featured
 ) VALUES (
-    'd427e8aa-d3c7-46e3-80f5-f955571934ea',
+    '69ddecaa-8db1-4ce2-9b25-7072185ed0ef',
     'SMS Service End-to-End: MO → SMSC → MT Delivery',
     'Complete SMS service flow from Mobile Originated to Mobile Terminated delivery via SMSC',
     'LTE',
@@ -88,7 +88,7 @@ INSERT INTO test_cases (
     estimated_duration_minutes, automation_level, review_status, layer,
     standard_reference, is_active, is_premium, is_featured
 ) VALUES (
-    '7004525a-5fb2-4654-bc91-44ccde3eb358',
+    '42b17322-78b3-4dbc-a8df-b6a558053e47',
     '5G→LTE Handover End-to-End: Measurement → Handover → Bearer Update',
     'Complete 5G to LTE handover flow with measurement, handover command, and bearer update',
     'Multi',

--- a/database/insert_final_e2e_test_cases.sql
+++ b/database/insert_final_e2e_test_cases.sql
@@ -8,7 +8,7 @@ INSERT INTO test_cases (
     estimated_duration_minutes, automation_level, review_status, layer,
     standard_reference, is_active, is_premium, is_featured
 ) VALUES (
-    'e2482966-76f0-433b-bcf6-2473595f5792',
+    'ed22fcf5-2a2b-47a2-9f3c-ef858acc7695',
     'MO CSFB End-to-End: Voice Attempt → Fallback → Connection',
     'Complete Mobile Originated Circuit Switched Fallback flow for voice calls',
     'LTE',
@@ -88,7 +88,7 @@ INSERT INTO test_cases (
     estimated_duration_minutes, automation_level, review_status, layer,
     standard_reference, is_active, is_premium, is_featured
 ) VALUES (
-    'ae7132e4-5f3a-42b1-9a38-d513f4ab5e07',
+    '3df4003d-9e18-4a69-bdc3-4f1dc6c33afc',
     'LTE→5G Handover End-to-End: Measurement → Handover → QoS Update',
     'Complete LTE to 5G handover flow with measurement, handover command, and QoS update',
     'Multi',
@@ -170,7 +170,7 @@ INSERT INTO test_cases (
     estimated_duration_minutes, automation_level, review_status, layer,
     standard_reference, is_active, is_premium, is_featured
 ) VALUES (
-    'f951d40d-7c5b-44ce-b8e3-8af5a0ad4e6f',
+    '06816abe-0c38-403e-84f0-49b73fd81cbf',
     '3G→LTE Handover End-to-End: Measurement → Relocation → Bearer Update',
     'Complete 3G to LTE handover flow with measurement, relocation, and bearer update',
     'Multi',

--- a/database/insert_remaining_e2e_test_cases.sql
+++ b/database/insert_remaining_e2e_test_cases.sql
@@ -8,7 +8,7 @@ INSERT INTO test_cases (
     estimated_duration_minutes, automation_level, review_status, layer,
     standard_reference, is_active, is_premium, is_featured
 ) VALUES (
-    'a5131c90-ae41-4f5c-a2cb-2d4148022fb2',
+    '411effa9-a957-47fe-a433-ace7fa903c78',
     'MO Data End-to-End: PDP Activation → Data Transfer',
     'Complete Mobile Originated data flow with PDP context activation and data transfer',
     'LTE',
@@ -88,7 +88,7 @@ INSERT INTO test_cases (
     estimated_duration_minutes, automation_level, review_status, layer,
     standard_reference, is_active, is_premium, is_featured
 ) VALUES (
-    'd2aa6348-aa78-476a-aaa8-fbf7113d6b0b',
+    '1d97d068-d0bc-49f3-ac79-62b09ed621fc',
     'MT Data End-to-End: Paging → Data Delivery',
     'Complete Mobile Terminated data flow with paging and data delivery',
     'LTE',
@@ -168,7 +168,7 @@ INSERT INTO test_cases (
     estimated_duration_minutes, automation_level, review_status, layer,
     standard_reference, is_active, is_premium, is_featured
 ) VALUES (
-    '5eabd3f3-8c8a-4a0c-b3a6-b5dccc704966',
+    '3c77fd9c-5c3f-45cf-bcb3-5de29bb2ff27',
     'MT CSFB End-to-End: Voice Call → Fallback → Connection',
     'Complete Mobile Terminated Circuit Switched Fallback flow for voice calls',
     'LTE',


### PR DESCRIPTION
Update E2E test case UUIDs in SQL insert scripts to resolve duplicate key errors.

The previous IDs caused `duplicate key value violates unique constraint "test_cases_pkey"` errors. New unique UUIDs were generated and applied to all test cases across the three SQL files to ensure successful insertion.

---
<a href="https://cursor.com/background-agent?bcId=bc-5faa41a2-611a-462e-9a02-f1c0a4b3363f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5faa41a2-611a-462e-9a02-f1c0a4b3363f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

