### PR TITLE
Test data flow fix script

### DIFF
--- a/components/5glabx/components/DataFlowDebugger.tsx
+++ b/components/5glabx/components/DataFlowDebugger.tsx
@@ -323,7 +323,7 @@ const DataFlowDebugger: React.FC = () => {
                           {getStatusBadge(event.status)}
                         </div>
                         <span className="text-sm text-gray-500">
-                          {event.timestamp.toLocaleTimeString()}
+                          {event.timestamp ? new Date(event.timestamp).toLocaleTimeString() : 'N/A'}
                         </span>
                       </div>
                       <div className="text-sm">

--- a/components/5glabx/components/IntegrationTester.tsx
+++ b/components/5glabx/components/IntegrationTester.tsx
@@ -441,7 +441,7 @@ const IntegrationTester: React.FC = () => {
                           {getStatusBadge(result.status)}
                         </div>
                         <span className="text-sm text-gray-500">
-                          {result.timestamp.toLocaleTimeString()}
+                          {result.timestamp ? new Date(result.timestamp).toLocaleTimeString() : 'N/A'}
                         </span>
                       </div>
                       <p className="text-sm text-gray-700 mb-2">{result.details}</p>

--- a/components/5glabx/components/SimpleDataDisplay.tsx
+++ b/components/5glabx/components/SimpleDataDisplay.tsx
@@ -143,7 +143,7 @@ const SimpleDataDisplay: React.FC = () => {
             {testData.map((data, index) => (
               <div key={index} className="bg-white p-3 rounded border">
                 <div className="text-sm">
-                  <div><strong>Time:</strong> {data.timestamp?.toLocaleTimeString() || 'N/A'}</div>
+                  <div><strong>Time:</strong> {data.timestamp ? new Date(data.timestamp).toLocaleTimeString() : 'N/A'}</div>
                   <div><strong>Type:</strong> {data.type || 'Unknown'}</div>
                   <div><strong>Test Case:</strong> {data.testCaseId || 'N/A'}</div>
                   <div><strong>Messages:</strong> {data.testCaseData?.expectedMessages?.length || 0}</div>

--- a/components/logs/LogViewer.tsx
+++ b/components/logs/LogViewer.tsx
@@ -375,7 +375,7 @@ const LogViewer: React.FC<LogViewerProps> = ({
                         {getLevelIcon(log.level)}
                         {showTimestamp && (
                           <span className="text-xs text-gray-600">
-                            {log.timestamp.toLocaleTimeString()}
+                            {log.timestamp ? new Date(log.timestamp).toLocaleTimeString() : 'N/A'}
                           </span>
                         )}
                       </div>

--- a/components/logs/LogViewerWithAdapter.tsx
+++ b/components/logs/LogViewerWithAdapter.tsx
@@ -462,7 +462,7 @@ const LogViewerWithAdapter: React.FC<LogViewerProps> = ({
                                 <Badge variant="outline">{log.direction}</Badge>
                               )}
                               <span className="text-xs text-gray-500">
-                                {log.timestamp.toLocaleTimeString()}
+                                {log.timestamp ? new Date(log.timestamp).toLocaleTimeString() : 'N/A'}
                               </span>
                             </div>
                             

--- a/components/protocol-analyzer/ProtocolAnalyzerViewer.tsx
+++ b/components/protocol-analyzer/ProtocolAnalyzerViewer.tsx
@@ -524,7 +524,7 @@ const ProtocolAnalyzerViewer: React.FC<ProtocolAnalyzerViewerProps> = ({
                   <div key={index} className={`text-xs p-2 rounded ${getLogLevelColor(log.level)}`}>
                     <div className="flex items-center justify-between">
                       <span className="font-medium">{log.source}</span>
-                      <span>{log.timestamp.toLocaleTimeString()}</span>
+                      <span>{log.timestamp ? new Date(log.timestamp).toLocaleTimeString() : 'N/A'}</span>
                     </div>
                     <div className="mt-1">{log.message}</div>
                   </div>

--- a/test-timestamp-fix.js
+++ b/test-timestamp-fix.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify timestamp conversion fixes
+ * This script tests the timestamp handling that was causing the toLocaleTimeString error
+ */
+
+console.log('🔧 Testing Timestamp Conversion Fixes...\n');
+
+// Test data that mimics what the application receives
+const testData = {
+  timestamp: "2025-09-29T16:55:38.072Z", // ISO string format
+  timestampMs: 1727631338072, // Unix timestamp in milliseconds
+  timestampString: "16:55:38.123", // Already formatted string
+  timestampInvalid: null, // Invalid/null timestamp
+  timestampUndefined: undefined // Undefined timestamp
+};
+
+console.log('📊 Test Data:');
+console.log('  ISO String:', testData.timestamp);
+console.log('  Unix MS:', testData.timestampMs);
+console.log('  Formatted String:', testData.timestampString);
+console.log('  Invalid:', testData.timestampInvalid);
+console.log('  Undefined:', testData.timestampUndefined);
+console.log('');
+
+// Test the old problematic approach (this would cause the error)
+console.log('❌ OLD APPROACH (would cause error):');
+try {
+  // This would fail: testData.timestamp.toLocaleTimeString()
+  console.log('  Would fail: timestamp.toLocaleTimeString() on string');
+} catch (error) {
+  console.log('  Error:', error.message);
+}
+
+// Test the new fixed approach
+console.log('\n✅ NEW APPROACH (fixed):');
+
+// Test 1: ISO string timestamp
+try {
+  const result1 = testData.timestamp ? new Date(testData.timestamp).toLocaleTimeString() : 'N/A';
+  console.log('  ISO String → Date:', result1);
+} catch (error) {
+  console.log('  Error with ISO string:', error.message);
+}
+
+// Test 2: Unix timestamp in milliseconds
+try {
+  const result2 = testData.timestampMs ? new Date(testData.timestampMs).toLocaleTimeString() : 'N/A';
+  console.log('  Unix MS → Date:', result2);
+} catch (error) {
+  console.log('  Error with Unix MS:', error.message);
+}
+
+// Test 3: Already formatted string (should handle gracefully)
+try {
+  const result3 = testData.timestampString ? new Date(testData.timestampString).toLocaleTimeString() : 'N/A';
+  console.log('  Formatted String → Date:', result3);
+} catch (error) {
+  console.log('  Error with formatted string:', error.message);
+}
+
+// Test 4: Invalid/null timestamp
+try {
+  const result4 = testData.timestampInvalid ? new Date(testData.timestampInvalid).toLocaleTimeString() : 'N/A';
+  console.log('  Invalid → Date:', result4);
+} catch (error) {
+  console.log('  Error with invalid:', error.message);
+}
+
+// Test 5: Undefined timestamp
+try {
+  const result5 = testData.timestampUndefined ? new Date(testData.timestampUndefined).toLocaleTimeString() : 'N/A';
+  console.log('  Undefined → Date:', result5);
+} catch (error) {
+  console.log('  Error with undefined:', error.message);
+}
+
+// Test 6: Edge case - empty string
+try {
+  const emptyString = "";
+  const result6 = emptyString ? new Date(emptyString).toLocaleTimeString() : 'N/A';
+  console.log('  Empty String → Date:', result6);
+} catch (error) {
+  console.log('  Error with empty string:', error.message);
+}
+
+console.log('\n🎯 FIXES APPLIED:');
+console.log('==================');
+console.log('✅ 1. SimpleDataDisplay.tsx - Fixed data.timestamp.toLocaleTimeString()');
+console.log('✅ 2. DataFlowDebugger.tsx - Fixed event.timestamp.toLocaleTimeString()');
+console.log('✅ 3. IntegrationTester.tsx - Fixed result.timestamp.toLocaleTimeString()');
+console.log('✅ 4. LogViewerWithAdapter.tsx - Fixed log.timestamp.toLocaleTimeString()');
+console.log('✅ 5. LogViewer.tsx - Fixed log.timestamp.toLocaleTimeString()');
+console.log('✅ 6. ProtocolAnalyzerViewer.tsx - Fixed log.timestamp.toLocaleTimeString()');
+
+console.log('\n🧪 TESTING INSTRUCTIONS:');
+console.log('========================');
+console.log('1. Refresh the application in your browser');
+console.log('2. The "t.toLocaleTimeString is not a function" error should be resolved');
+console.log('3. All timestamp displays should now show proper time formatting');
+console.log('4. Invalid timestamps will show "N/A" instead of causing errors');
+
+console.log('\n🔍 VERIFICATION:');
+console.log('================');
+console.log('The fix ensures that:');
+console.log('- String timestamps are converted to Date objects before calling toLocaleTimeString()');
+console.log('- Invalid/null/undefined timestamps show "N/A" instead of causing errors');
+console.log('- All timestamp displays are now safe and won\'t crash the application');
+
+console.log('\n✅ Timestamp Fix Test Complete!');
+console.log('The application should now work without the toLocaleTimeString error.');


### PR DESCRIPTION
Fix `toLocaleTimeString` error by converting string timestamps to Date objects and handling null/undefined values.

The application was crashing due to `toLocaleTimeString()` being called on timestamp values that were strings instead of `Date` objects. This PR ensures all timestamps are properly converted or gracefully handled to prevent crashes.

---
<a href="https://cursor.com/background-agent?bcId=bc-433a31db-2730-4776-94ee-c49de3000332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-433a31db-2730-4776-94ee-c49de3000332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

