### PR TITLE
Debug class instantiation error

### DIFF
--- a/app/user-dashboard/page.tsx
+++ b/app/user-dashboard/page.tsx
@@ -27,7 +27,9 @@ const UserDashboard: React.FC = () => {
         // Load DataFormatAdapter
         const { DataFormatAdapter } = await import('@/utils/DataFormatAdapter');
         if (typeof window !== 'undefined') {
-          (window as any).DataFormatAdapter = DataFormatAdapter;
+          if (!(window as any).DataFormatAdapter) {
+            (window as any).DataFormatAdapter = DataFormatAdapter;
+          }
           console.log('✅ DataFormatAdapter loaded successfully');
         }
 

--- a/utils/DataFormatAdapter.js
+++ b/utils/DataFormatAdapter.js
@@ -1259,13 +1259,13 @@ class DataFormatAdapter {
   }
 }
 
-// Export for both Node.js and browser environments
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = DataFormatAdapter;
-  module.exports.DataFormatAdapter = DataFormatAdapter;
-} else if (typeof window !== 'undefined') {
-  window.DataFormatAdapter = new DataFormatAdapter();
-  console.log('✅ DataFormatAdapter loaded into window object');
+// Attach class to window in browser environments without instantiating
+if (typeof window !== 'undefined') {
+  // Do not overwrite if already defined
+  if (!(window).DataFormatAdapter) {
+    (window).DataFormatAdapter = DataFormatAdapter;
+    console.log('✅ DataFormatAdapter loaded into window object');
+  }
 }
 
 export default DataFormatAdapter;


### PR DESCRIPTION
Fix `TypeError: Class constructor cannot be invoked without 'new'` by ensuring `window.DataFormatAdapter` consistently holds the class definition.

The error occurred because `window.DataFormatAdapter` was inconsistently treated as both a class and an instance, leading to React hooks attempting to invoke it incorrectly. This PR updates `DataFormatAdapter.js` to always assign the class itself to `window` (if not already present) and `page.tsx` to guard against reassigning it.

---
<a href="https://cursor.com/background-agent?bcId=bc-adc88f19-015a-46f0-a2af-35aa72abedd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-adc88f19-015a-46f0-a2af-35aa72abedd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

